### PR TITLE
Setup actions

### DIFF
--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -103,9 +103,9 @@ export default mudConfig({
                 roomType: "RoomType",
                 txtDefId: "bytes32",
                 description: "string", //temp
-                objectIds: "uint32[]",
-                dirObjIds: "uint32[]",
-                players: "uint32[]"
+                objectIds: "uint32[32]",
+                dirObjIds: "uint32[32]",
+                players: "uint32[32]"
             },
         },
         // Actions have a NESSy property
@@ -143,7 +143,7 @@ export default mudConfig({
                 matType: "MaterialType",
                 destId: "uint32",
                 txtDefId: "bytes32",
-                objectActionIds: "uint32[]" // Open/Lock/Break etc
+                objectActionIds: "uint32[32]" // Open/Lock/Break etc
             },
         },
         ObjectStore: {
@@ -154,7 +154,7 @@ export default mudConfig({
                 objectType: "ObjectType",
                 materialType: "MaterialType",
                 txtDefId: "bytes32",
-                objectActionIds: "uint32[]",
+                objectActionIds: "uint32[32]",
                 description: "string"
             },
         },
@@ -195,7 +195,7 @@ export default mudConfig({
             },
             valueSchema: {
                 roomId: "uint32",
-                objectIds: "uint32[]",
+                objectIds: "uint32[32]",
             },
         },
     },

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -120,10 +120,10 @@ export default mudConfig({
             },
             valueSchema: {
                 actionType: "ActionType",
-                texDefId: "bytes32", // not sure we really need this tbh
+                txtDefId: "bytes32", // @DDT shoud we have a TRUE abd FALSe text here maybe?
                 // the next 2 are a pair really a door is a good example
-                // is it nESSy: ie. is it just a prop
-                // if it IS then CAN it be, like has it been unlocked
+                // is it enabled: ie. can it be done
+                // if it CAN then HAS it been, like has it been unlocked
                 enabled: "bool", // can it be used?
                 dBit: "bool" // is it done, LOCK->lockED, CLOSE -> closeED etc
             },

--- a/packages/contracts/src/codegen/tables/ActionStore.sol
+++ b/packages/contracts/src/codegen/tables/ActionStore.sol
@@ -34,7 +34,7 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 
 struct ActionStoreData {
   ActionType actionType;
-  bytes32 texDefId;
+  bytes32 txtDefId;
   bool enabled;
   bool dBit;
 }
@@ -89,7 +89,7 @@ library ActionStore {
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](4);
     fieldNames[0] = "actionType";
-    fieldNames[1] = "texDefId";
+    fieldNames[1] = "txtDefId";
     fieldNames[2] = "enabled";
     fieldNames[3] = "dBit";
   }
@@ -151,9 +151,9 @@ library ActionStore {
   }
 
   /**
-   * @notice Get texDefId.
+   * @notice Get txtDefId.
    */
-  function getTexDefId(uint32 actionId) internal view returns (bytes32 texDefId) {
+  function getTxtDefId(uint32 actionId) internal view returns (bytes32 txtDefId) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(actionId));
 
@@ -162,9 +162,9 @@ library ActionStore {
   }
 
   /**
-   * @notice Get texDefId.
+   * @notice Get txtDefId.
    */
-  function _getTexDefId(uint32 actionId) internal view returns (bytes32 texDefId) {
+  function _getTxtDefId(uint32 actionId) internal view returns (bytes32 txtDefId) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(actionId));
 
@@ -173,23 +173,23 @@ library ActionStore {
   }
 
   /**
-   * @notice Set texDefId.
+   * @notice Set txtDefId.
    */
-  function setTexDefId(uint32 actionId, bytes32 texDefId) internal {
+  function setTxtDefId(uint32 actionId, bytes32 txtDefId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(actionId));
 
-    StoreSwitch.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((texDefId)), _fieldLayout);
+    StoreSwitch.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((txtDefId)), _fieldLayout);
   }
 
   /**
-   * @notice Set texDefId.
+   * @notice Set txtDefId.
    */
-  function _setTexDefId(uint32 actionId, bytes32 texDefId) internal {
+  function _setTxtDefId(uint32 actionId, bytes32 txtDefId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(actionId));
 
-    StoreCore.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((texDefId)), _fieldLayout);
+    StoreCore.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((txtDefId)), _fieldLayout);
   }
 
   /**
@@ -309,8 +309,8 @@ library ActionStore {
   /**
    * @notice Set the full data using individual values.
    */
-  function set(uint32 actionId, ActionType actionType, bytes32 texDefId, bool enabled, bool dBit) internal {
-    bytes memory _staticData = encodeStatic(actionType, texDefId, enabled, dBit);
+  function set(uint32 actionId, ActionType actionType, bytes32 txtDefId, bool enabled, bool dBit) internal {
+    bytes memory _staticData = encodeStatic(actionType, txtDefId, enabled, dBit);
 
     PackedCounter _encodedLengths;
     bytes memory _dynamicData;
@@ -324,8 +324,8 @@ library ActionStore {
   /**
    * @notice Set the full data using individual values.
    */
-  function _set(uint32 actionId, ActionType actionType, bytes32 texDefId, bool enabled, bool dBit) internal {
-    bytes memory _staticData = encodeStatic(actionType, texDefId, enabled, dBit);
+  function _set(uint32 actionId, ActionType actionType, bytes32 txtDefId, bool enabled, bool dBit) internal {
+    bytes memory _staticData = encodeStatic(actionType, txtDefId, enabled, dBit);
 
     PackedCounter _encodedLengths;
     bytes memory _dynamicData;
@@ -340,7 +340,7 @@ library ActionStore {
    * @notice Set the full data using the data struct.
    */
   function set(uint32 actionId, ActionStoreData memory _table) internal {
-    bytes memory _staticData = encodeStatic(_table.actionType, _table.texDefId, _table.enabled, _table.dBit);
+    bytes memory _staticData = encodeStatic(_table.actionType, _table.txtDefId, _table.enabled, _table.dBit);
 
     PackedCounter _encodedLengths;
     bytes memory _dynamicData;
@@ -355,7 +355,7 @@ library ActionStore {
    * @notice Set the full data using the data struct.
    */
   function _set(uint32 actionId, ActionStoreData memory _table) internal {
-    bytes memory _staticData = encodeStatic(_table.actionType, _table.texDefId, _table.enabled, _table.dBit);
+    bytes memory _staticData = encodeStatic(_table.actionType, _table.txtDefId, _table.enabled, _table.dBit);
 
     PackedCounter _encodedLengths;
     bytes memory _dynamicData;
@@ -371,10 +371,10 @@ library ActionStore {
    */
   function decodeStatic(
     bytes memory _blob
-  ) internal pure returns (ActionType actionType, bytes32 texDefId, bool enabled, bool dBit) {
+  ) internal pure returns (ActionType actionType, bytes32 txtDefId, bool enabled, bool dBit) {
     actionType = ActionType(uint8(Bytes.slice1(_blob, 0)));
 
-    texDefId = (Bytes.slice32(_blob, 1));
+    txtDefId = (Bytes.slice32(_blob, 1));
 
     enabled = (_toBool(uint8(Bytes.slice1(_blob, 33))));
 
@@ -392,7 +392,7 @@ library ActionStore {
     PackedCounter,
     bytes memory
   ) internal pure returns (ActionStoreData memory _table) {
-    (_table.actionType, _table.texDefId, _table.enabled, _table.dBit) = decodeStatic(_staticData);
+    (_table.actionType, _table.txtDefId, _table.enabled, _table.dBit) = decodeStatic(_staticData);
   }
 
   /**
@@ -421,11 +421,11 @@ library ActionStore {
    */
   function encodeStatic(
     ActionType actionType,
-    bytes32 texDefId,
+    bytes32 txtDefId,
     bool enabled,
     bool dBit
   ) internal pure returns (bytes memory) {
-    return abi.encodePacked(actionType, texDefId, enabled, dBit);
+    return abi.encodePacked(actionType, txtDefId, enabled, dBit);
   }
 
   /**
@@ -436,11 +436,11 @@ library ActionStore {
    */
   function encode(
     ActionType actionType,
-    bytes32 texDefId,
+    bytes32 txtDefId,
     bool enabled,
     bool dBit
   ) internal pure returns (bytes memory, PackedCounter, bytes memory) {
-    bytes memory _staticData = encodeStatic(actionType, texDefId, enabled, dBit);
+    bytes memory _staticData = encodeStatic(actionType, txtDefId, enabled, dBit);
 
     PackedCounter _encodedLengths;
     bytes memory _dynamicData;

--- a/packages/contracts/src/codegen/tables/DirObjectStore.sol
+++ b/packages/contracts/src/codegen/tables/DirObjectStore.sol
@@ -38,7 +38,7 @@ struct DirObjectStoreData {
   MaterialType matType;
   uint32 destId;
   bytes32 txtDefId;
-  uint32[] objectActionIds;
+  uint32[32] objectActionIds;
 }
 
 library DirObjectStore {
@@ -327,43 +327,43 @@ library DirObjectStore {
   /**
    * @notice Get objectActionIds.
    */
-  function getObjectActionIds(uint32 dirObjId) internal view returns (uint32[] memory objectActionIds) {
+  function getObjectActionIds(uint32 dirObjId) internal view returns (uint32[32] memory objectActionIds) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(dirObjId));
 
     bytes memory _blob = StoreSwitch.getDynamicField(_tableId, _keyTuple, 0);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Get objectActionIds.
    */
-  function _getObjectActionIds(uint32 dirObjId) internal view returns (uint32[] memory objectActionIds) {
+  function _getObjectActionIds(uint32 dirObjId) internal view returns (uint32[32] memory objectActionIds) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(dirObjId));
 
     bytes memory _blob = StoreCore.getDynamicField(_tableId, _keyTuple, 0);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Set objectActionIds.
    */
-  function setObjectActionIds(uint32 dirObjId, uint32[] memory objectActionIds) internal {
+  function setObjectActionIds(uint32 dirObjId, uint32[32] memory objectActionIds) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(dirObjId));
 
-    StoreSwitch.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode((objectActionIds)));
+    StoreSwitch.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_uint32_32(objectActionIds)));
   }
 
   /**
    * @notice Set objectActionIds.
    */
-  function _setObjectActionIds(uint32 dirObjId, uint32[] memory objectActionIds) internal {
+  function _setObjectActionIds(uint32 dirObjId, uint32[32] memory objectActionIds) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(dirObjId));
 
-    StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode((objectActionIds)));
+    StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_uint32_32(objectActionIds)));
   }
 
   /**
@@ -526,7 +526,7 @@ library DirObjectStore {
     MaterialType matType,
     uint32 destId,
     bytes32 txtDefId,
-    uint32[] memory objectActionIds
+    uint32[32] memory objectActionIds
   ) internal {
     bytes memory _staticData = encodeStatic(objType, dirType, matType, destId, txtDefId);
 
@@ -549,7 +549,7 @@ library DirObjectStore {
     MaterialType matType,
     uint32 destId,
     bytes32 txtDefId,
-    uint32[] memory objectActionIds
+    uint32[32] memory objectActionIds
   ) internal {
     bytes memory _staticData = encodeStatic(objType, dirType, matType, destId, txtDefId);
 
@@ -631,13 +631,13 @@ library DirObjectStore {
   function decodeDynamic(
     PackedCounter _encodedLengths,
     bytes memory _blob
-  ) internal pure returns (uint32[] memory objectActionIds) {
+  ) internal pure returns (uint32[32] memory objectActionIds) {
     uint256 _start;
     uint256 _end;
     unchecked {
       _end = _encodedLengths.atIndex(0);
     }
-    objectActionIds = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+    objectActionIds = toStaticArray_uint32_32(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
   }
 
   /**
@@ -694,7 +694,7 @@ library DirObjectStore {
    * @notice Tightly pack dynamic data lengths using this table's schema.
    * @return _encodedLengths The lengths of the dynamic fields (packed into a single bytes32 value).
    */
-  function encodeLengths(uint32[] memory objectActionIds) internal pure returns (PackedCounter _encodedLengths) {
+  function encodeLengths(uint32[32] memory objectActionIds) internal pure returns (PackedCounter _encodedLengths) {
     // Lengths are effectively checked during copy by 2**40 bytes exceeding gas limits
     unchecked {
       _encodedLengths = PackedCounterLib.pack(objectActionIds.length * 4);
@@ -705,8 +705,8 @@ library DirObjectStore {
    * @notice Tightly pack dynamic (variable length) data using this table's schema.
    * @return The dynamic data, encoded into a sequence of bytes.
    */
-  function encodeDynamic(uint32[] memory objectActionIds) internal pure returns (bytes memory) {
-    return abi.encodePacked(EncodeArray.encode((objectActionIds)));
+  function encodeDynamic(uint32[32] memory objectActionIds) internal pure returns (bytes memory) {
+    return abi.encodePacked(EncodeArray.encode(fromStaticArray_uint32_32(objectActionIds)));
   }
 
   /**
@@ -721,7 +721,7 @@ library DirObjectStore {
     MaterialType matType,
     uint32 destId,
     bytes32 txtDefId,
-    uint32[] memory objectActionIds
+    uint32[32] memory objectActionIds
   ) internal pure returns (bytes memory, PackedCounter, bytes memory) {
     bytes memory _staticData = encodeStatic(objType, dirType, matType, destId, txtDefId);
 
@@ -740,4 +740,43 @@ library DirObjectStore {
 
     return _keyTuple;
   }
+}
+
+/**
+ * @notice Cast a dynamic array to a static array.
+ * @dev In memory static arrays are just dynamic arrays without the 32 length bytes,
+ * so this function moves the pointer to the first element of the dynamic array.
+ * If the length of the dynamic array is smaller than the static length,
+ * the function returns an uninitialized array to avoid memory corruption.
+ * @param _value The dynamic array to cast.
+ * @return _result The static array.
+ */
+function toStaticArray_uint32_32(uint32[] memory _value) pure returns (uint32[32] memory _result) {
+  if (_value.length < 32) {
+    // return an uninitialized array if the length is smaller than the fixed length to avoid memory corruption
+    return _result;
+  } else {
+    // in memory static arrays are just dynamic arrays without the 32 length bytes
+    // (without the length check this could lead to memory corruption)
+    assembly {
+      _result := add(_value, 0x20)
+    }
+  }
+}
+
+/**
+ * @notice Copy a static array to a dynamic array.
+ * @dev Static arrays don't have a length prefix, so this function copies the memory from the static array to a new dynamic array.
+ * @param _value The static array to copy.
+ * @return _result The dynamic array.
+ */
+function fromStaticArray_uint32_32(uint32[32] memory _value) pure returns (uint32[] memory _result) {
+  _result = new uint32[](32);
+  uint256 fromPointer;
+  uint256 toPointer;
+  assembly {
+    fromPointer := _value
+    toPointer := add(_result, 0x20)
+  }
+  Memory.copy(fromPointer, toPointer, 1024);
 }

--- a/packages/contracts/src/codegen/tables/RoomStore.sol
+++ b/packages/contracts/src/codegen/tables/RoomStore.sol
@@ -36,9 +36,9 @@ struct RoomStoreData {
   RoomType roomType;
   bytes32 txtDefId;
   string description;
-  uint32[] objectIds;
-  uint32[] dirObjIds;
-  uint32[] players;
+  uint32[32] objectIds;
+  uint32[32] dirObjIds;
+  uint32[32] players;
 }
 
 library RoomStore {
@@ -363,43 +363,43 @@ library RoomStore {
   /**
    * @notice Get objectIds.
    */
-  function getObjectIds(uint32 roomId) internal view returns (uint32[] memory objectIds) {
+  function getObjectIds(uint32 roomId) internal view returns (uint32[32] memory objectIds) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
     bytes memory _blob = StoreSwitch.getDynamicField(_tableId, _keyTuple, 1);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Get objectIds.
    */
-  function _getObjectIds(uint32 roomId) internal view returns (uint32[] memory objectIds) {
+  function _getObjectIds(uint32 roomId) internal view returns (uint32[32] memory objectIds) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
     bytes memory _blob = StoreCore.getDynamicField(_tableId, _keyTuple, 1);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Set objectIds.
    */
-  function setObjectIds(uint32 roomId, uint32[] memory objectIds) internal {
+  function setObjectIds(uint32 roomId, uint32[32] memory objectIds) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
-    StoreSwitch.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode((objectIds)));
+    StoreSwitch.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_32(objectIds)));
   }
 
   /**
    * @notice Set objectIds.
    */
-  function _setObjectIds(uint32 roomId, uint32[] memory objectIds) internal {
+  function _setObjectIds(uint32 roomId, uint32[32] memory objectIds) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
-    StoreCore.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode((objectIds)));
+    StoreCore.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_32(objectIds)));
   }
 
   /**
@@ -525,43 +525,43 @@ library RoomStore {
   /**
    * @notice Get dirObjIds.
    */
-  function getDirObjIds(uint32 roomId) internal view returns (uint32[] memory dirObjIds) {
+  function getDirObjIds(uint32 roomId) internal view returns (uint32[32] memory dirObjIds) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
     bytes memory _blob = StoreSwitch.getDynamicField(_tableId, _keyTuple, 2);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Get dirObjIds.
    */
-  function _getDirObjIds(uint32 roomId) internal view returns (uint32[] memory dirObjIds) {
+  function _getDirObjIds(uint32 roomId) internal view returns (uint32[32] memory dirObjIds) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
     bytes memory _blob = StoreCore.getDynamicField(_tableId, _keyTuple, 2);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Set dirObjIds.
    */
-  function setDirObjIds(uint32 roomId, uint32[] memory dirObjIds) internal {
+  function setDirObjIds(uint32 roomId, uint32[32] memory dirObjIds) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
-    StoreSwitch.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode((dirObjIds)));
+    StoreSwitch.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_32(dirObjIds)));
   }
 
   /**
    * @notice Set dirObjIds.
    */
-  function _setDirObjIds(uint32 roomId, uint32[] memory dirObjIds) internal {
+  function _setDirObjIds(uint32 roomId, uint32[32] memory dirObjIds) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
-    StoreCore.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode((dirObjIds)));
+    StoreCore.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_32(dirObjIds)));
   }
 
   /**
@@ -687,43 +687,43 @@ library RoomStore {
   /**
    * @notice Get players.
    */
-  function getPlayers(uint32 roomId) internal view returns (uint32[] memory players) {
+  function getPlayers(uint32 roomId) internal view returns (uint32[32] memory players) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
     bytes memory _blob = StoreSwitch.getDynamicField(_tableId, _keyTuple, 3);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Get players.
    */
-  function _getPlayers(uint32 roomId) internal view returns (uint32[] memory players) {
+  function _getPlayers(uint32 roomId) internal view returns (uint32[32] memory players) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
     bytes memory _blob = StoreCore.getDynamicField(_tableId, _keyTuple, 3);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+    return toStaticArray_uint32_32(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /**
    * @notice Set players.
    */
-  function setPlayers(uint32 roomId, uint32[] memory players) internal {
+  function setPlayers(uint32 roomId, uint32[32] memory players) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
-    StoreSwitch.setDynamicField(_tableId, _keyTuple, 3, EncodeArray.encode((players)));
+    StoreSwitch.setDynamicField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_32(players)));
   }
 
   /**
    * @notice Set players.
    */
-  function _setPlayers(uint32 roomId, uint32[] memory players) internal {
+  function _setPlayers(uint32 roomId, uint32[32] memory players) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(roomId));
 
-    StoreCore.setDynamicField(_tableId, _keyTuple, 3, EncodeArray.encode((players)));
+    StoreCore.setDynamicField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_32(players)));
   }
 
   /**
@@ -884,9 +884,9 @@ library RoomStore {
     RoomType roomType,
     bytes32 txtDefId,
     string memory description,
-    uint32[] memory objectIds,
-    uint32[] memory dirObjIds,
-    uint32[] memory players
+    uint32[32] memory objectIds,
+    uint32[32] memory dirObjIds,
+    uint32[32] memory players
   ) internal {
     bytes memory _staticData = encodeStatic(roomType, txtDefId);
 
@@ -907,9 +907,9 @@ library RoomStore {
     RoomType roomType,
     bytes32 txtDefId,
     string memory description,
-    uint32[] memory objectIds,
-    uint32[] memory dirObjIds,
-    uint32[] memory players
+    uint32[32] memory objectIds,
+    uint32[32] memory dirObjIds,
+    uint32[32] memory players
   ) internal {
     bytes memory _staticData = encodeStatic(roomType, txtDefId);
 
@@ -980,7 +980,12 @@ library RoomStore {
   )
     internal
     pure
-    returns (string memory description, uint32[] memory objectIds, uint32[] memory dirObjIds, uint32[] memory players)
+    returns (
+      string memory description,
+      uint32[32] memory objectIds,
+      uint32[32] memory dirObjIds,
+      uint32[32] memory players
+    )
   {
     uint256 _start;
     uint256 _end;
@@ -993,19 +998,19 @@ library RoomStore {
     unchecked {
       _end += _encodedLengths.atIndex(1);
     }
-    objectIds = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+    objectIds = toStaticArray_uint32_32(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
 
     _start = _end;
     unchecked {
       _end += _encodedLengths.atIndex(2);
     }
-    dirObjIds = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+    dirObjIds = toStaticArray_uint32_32(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
 
     _start = _end;
     unchecked {
       _end += _encodedLengths.atIndex(3);
     }
-    players = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+    players = toStaticArray_uint32_32(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
   }
 
   /**
@@ -1061,9 +1066,9 @@ library RoomStore {
    */
   function encodeLengths(
     string memory description,
-    uint32[] memory objectIds,
-    uint32[] memory dirObjIds,
-    uint32[] memory players
+    uint32[32] memory objectIds,
+    uint32[32] memory dirObjIds,
+    uint32[32] memory players
   ) internal pure returns (PackedCounter _encodedLengths) {
     // Lengths are effectively checked during copy by 2**40 bytes exceeding gas limits
     unchecked {
@@ -1082,16 +1087,16 @@ library RoomStore {
    */
   function encodeDynamic(
     string memory description,
-    uint32[] memory objectIds,
-    uint32[] memory dirObjIds,
-    uint32[] memory players
+    uint32[32] memory objectIds,
+    uint32[32] memory dirObjIds,
+    uint32[32] memory players
   ) internal pure returns (bytes memory) {
     return
       abi.encodePacked(
         bytes((description)),
-        EncodeArray.encode((objectIds)),
-        EncodeArray.encode((dirObjIds)),
-        EncodeArray.encode((players))
+        EncodeArray.encode(fromStaticArray_uint32_32(objectIds)),
+        EncodeArray.encode(fromStaticArray_uint32_32(dirObjIds)),
+        EncodeArray.encode(fromStaticArray_uint32_32(players))
       );
   }
 
@@ -1105,9 +1110,9 @@ library RoomStore {
     RoomType roomType,
     bytes32 txtDefId,
     string memory description,
-    uint32[] memory objectIds,
-    uint32[] memory dirObjIds,
-    uint32[] memory players
+    uint32[32] memory objectIds,
+    uint32[32] memory dirObjIds,
+    uint32[32] memory players
   ) internal pure returns (bytes memory, PackedCounter, bytes memory) {
     bytes memory _staticData = encodeStatic(roomType, txtDefId);
 
@@ -1126,4 +1131,43 @@ library RoomStore {
 
     return _keyTuple;
   }
+}
+
+/**
+ * @notice Cast a dynamic array to a static array.
+ * @dev In memory static arrays are just dynamic arrays without the 32 length bytes,
+ * so this function moves the pointer to the first element of the dynamic array.
+ * If the length of the dynamic array is smaller than the static length,
+ * the function returns an uninitialized array to avoid memory corruption.
+ * @param _value The dynamic array to cast.
+ * @return _result The static array.
+ */
+function toStaticArray_uint32_32(uint32[] memory _value) pure returns (uint32[32] memory _result) {
+  if (_value.length < 32) {
+    // return an uninitialized array if the length is smaller than the fixed length to avoid memory corruption
+    return _result;
+  } else {
+    // in memory static arrays are just dynamic arrays without the 32 length bytes
+    // (without the length check this could lead to memory corruption)
+    assembly {
+      _result := add(_value, 0x20)
+    }
+  }
+}
+
+/**
+ * @notice Copy a static array to a dynamic array.
+ * @dev Static arrays don't have a length prefix, so this function copies the memory from the static array to a new dynamic array.
+ * @param _value The static array to copy.
+ * @return _result The dynamic array.
+ */
+function fromStaticArray_uint32_32(uint32[32] memory _value) pure returns (uint32[] memory _result) {
+  _result = new uint32[](32);
+  uint256 fromPointer;
+  uint256 toPointer;
+  assembly {
+    fromPointer := _value
+    toPointer := add(_result, 0x20)
+  }
+  Memory.copy(fromPointer, toPointer, 1024);
 }

--- a/packages/contracts/src/codegen/world/IDirectionSystem.sol
+++ b/packages/contracts/src/codegen/world/IDirectionSystem.sol
@@ -13,5 +13,5 @@ interface IDirectionSystem {
   function meat_DirectionSystem_getNextRoom(
     string[] memory tokens,
     uint32 currRm
-  ) external returns (uint8 e, uint32 nxtRm);
+  ) external returns (uint8 e, uint32 nxt);
 }

--- a/packages/contracts/src/codegen/world/IGameSetupSystem.sol
+++ b/packages/contracts/src/codegen/world/IGameSetupSystem.sol
@@ -10,12 +10,10 @@ pragma solidity >=0.8.21;
 interface IGameSetupSystem {
   function meat_GameSetupSystem_init() external returns (uint32);
 
-  function meat_GameSetupSystem_getArrayValue(uint8 index) external view returns (uint32, uint8 er);
-
   function meat_GameSetupSystem_createPlace(
     uint32 id,
-    uint32[] memory dirObjects,
-    uint32[] memory objects,
+    uint32[32] memory dirObjects,
+    uint32[32] memory objects,
     bytes32 txtId
   ) external;
 }

--- a/packages/contracts/src/constants/defines.sol
+++ b/packages/contracts/src/constants/defines.sol
@@ -23,11 +23,13 @@ library GameConstants {
     uint8 public constant WEST_DIR = 8;         // 0x1000
 }
 
+
+
 // some result codes (from game commands)
 library ResCodes {
-    uint8 public constant GO_NO_EXIT = 8; // Error DirectionRoutine DR
+    uint8 public constant GO_NO_EXIT = 9; // Error DirectionRoutine DR
     // We use a custom return type for LOOK's
-    // becaseu we cant retutn a 0 for no err unlike the rest of our commands
+    // because we cant return a 0 for no err unlike the rest of our commands
     uint8 public constant LK_RT = 8; 
 }
 
@@ -41,7 +43,7 @@ library ErrCodes {
     uint8 public constant ER_PR_NOP = 127;
     uint8 public constant ER_PR_TK_C1 = 128; // < MIN TOKS 
     uint8 public constant ER_PR_NO = 129; // Error No DirectObject
-    uint8 public constant ER_LK_NOP = 130; // Error No DirectObject
+    uint8 public constant ER_LK_NOP = 130; // Error Bad Look Command
     uint8 public constant ER_AR_BNDS = 131; // Error No DirectObject
 
 }

--- a/packages/contracts/src/libs/KickLib.sol
+++ b/packages/contracts/src/libs/KickLib.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.21;
 
 import {console} from "forge-std/console.sol";
 import {IWorld} from '../codegen/world/IWorld.sol';
-
 import {ObjectType, ActionType} from '../codegen/common.sol';
 import {DirObjectStore, DirObjectStoreData, ActionStoreData, ActionStore, RoomStore, ObjectStore, Output} from '../codegen/index.sol';
 
@@ -17,7 +16,7 @@ library Kick {
         string memory tok = tokens[1];
         ObjectType objType = IWorld(wrld).meat_TokeniserSystem_getObjectType(tok);
         if (objType != ObjectType.None) {
-            uint32[] memory objIds = RoomStore.getObjectIds(curRmId);
+            uint32[32] memory objIds = RoomStore.getObjectIds(curRmId);
             // find the object
             for (uint8 objectIndex = 0; objectIndex < objIds.length; objectIndex++) {
                 ObjectType testType = ObjectStore.getObjectType(objIds[objectIndex]);
@@ -28,7 +27,7 @@ library Kick {
                     // we need a check to see if the object is actually kickable
 
                     // the exits for this room
-                    uint32[] memory dirObjIds = RoomStore.getDirObjIds(curRmId);
+                    uint32[32] memory dirObjIds = RoomStore.getDirObjIds(curRmId);
                     console.log('-------->dirObjIds.length = %d', dirObjIds.length);
                     // iterate through direction objects
                     for (uint8 dirObjectIndex = 0; dirObjectIndex < dirObjIds.length; dirObjectIndex++) {

--- a/packages/contracts/src/libs/LookLib.sol
+++ b/packages/contracts/src/libs/LookLib.sol
@@ -76,7 +76,7 @@ library LookAt {
         return desc;
     }
 
-    function _genObjDesc(uint32[] memory objs) internal view returns (string memory) {
+    function _genObjDesc(uint32[32] memory objs) internal view returns (string memory) {
         if (objs[0] != 0) {// if the first item is 0 then there are no objects
 
             string memory objsDesc = "\nYou can alse see a ";
@@ -107,7 +107,7 @@ library LookAt {
 
     
     // there is a PATH made os mud to the DIR | there is a wood door to the 
-    function _genExitDesc(uint32[] memory objs, address wrld) internal view returns (string memory) {
+    function _genExitDesc(uint32[32] memory objs, address wrld) internal view returns (string memory) {
         if (objs[0] != 0) {// if the first item is 0 then there are no objects
             string memory exitsDesc = "\nThere is a ";
             for(uint8 i = 0; i < objs.length; i++) {

--- a/packages/contracts/src/systems/DirectionSystem.sol
+++ b/packages/contracts/src/systems/DirectionSystem.sol
@@ -71,8 +71,6 @@ contract DirectionSystem is System {
        return true; //canMove;
     }
 
-
-    /* NB this is ONLY checking that an exit exists TODO add an openable check */
     function _directionCheck (uint32 rId, DirectionType d) private view returns (bool success, uint32 next) {
         //console.log("---->DC room:", rId, "---> DR:", uint8(d));
         uint32[] memory exitIds = RoomStore.getDirObjIds(rId);  

--- a/packages/contracts/src/systems/GameSetupSystem.sol
+++ b/packages/contracts/src/systems/GameSetupSystem.sol
@@ -90,25 +90,34 @@ contract GameSetupSystem is System {
         uint32[] memory oids = new uint32[](MAXOBJ);
         uint32[] memory aids = new uint32[](MAXOBJ);
 
-        // KPLAIN
+        // KPLAIN -> N, E
+        aids[0] = createAction(ActionType.Open, "the door opens with a farty noise\n"
+                                "oddly you can actually smell fart",
+                                true, true);  
 
         dids[0] = createDirObj(DirectionType.North, KBarn, 
                               DirObjectType.Path, MaterialType.Dirt, 
                               "path", aids);
 
+        aids[1] = createAction(ActionType.Open, "the door opens and a small hinge demon curses you\n"
+                                "your nose is really itchy",
+                                true, true);  
+
         dids[1] = createDirObj(DirectionType.East, KMountainPath, 
                               DirObjectType.Path, MaterialType.Mud,
                               "path", aids);
-        
+       clearArr(aids); 
 
-        // TODO creat a kick action and add to the football
+        // football is gay 
+        aids[0] = createAction(ActionType.Kick, "the ball (such as it is)"
+                                "bounces feebly\n then rolls into some fresh dog eggs\n"
+                                "none the less you briefly feel a little better",
+                                true, false);  
+
         oids[0] = createObject(ObjectType.Football, MaterialType.Flesh,
                                 "A slightly deflated knock off uefa football,\n"
                                 "not quite spherical, it's "
-                                "kickable though", "football");
-
-        // football is gay 
-        aids[0] = createAction(true, oids[0], ActionType.Kick, false);  
+                                "kickable though", "football", aids);
 
         RoomStore.setDescription(KPlain,  'a windswept plain');
         RoomStore.setRoomType(KPlain,  RoomType.Plain);
@@ -122,15 +131,25 @@ contract GameSetupSystem is System {
         createPlace(KPlain, dids, oids, tid_plain);
 
 
-        // KBARN
+        // KBARN -> S
         // TODO add a smash action to the window
         clearArr(dids);
         clearArr(oids);
-
+        clearArr(aids);
+        
+        aids[0] = createAction(ActionType.Open, "the door opens\n", true, true);
 
         dids[0] = createDirObj(DirectionType.South, KPlain,
                                 DirObjectType.Door, MaterialType.Wood,
                                 "door", aids); 
+        clearArr(aids);
+        aids[0] = createAction(ActionType.Open, "the window, glass and frame smashed"
+                                "falls open\n", true, false);
+        aids[1] = createAction(ActionType.Break, "I love the sound of breaking glass\n"
+                                "especially when I'm lonely, the panes and the frame shatter\n"
+                                "satisfyingly spreading broken joy on the floor"
+                                , true, false);
+
         dids[1] = createDirObj(DirectionType.East, KForest,
                                 DirObjectType.Window, MaterialType.Wood,
                                 "window", aids); 
@@ -147,10 +166,12 @@ contract GameSetupSystem is System {
 
         createPlace(KBarn, dids, oids, tid_barn);
 
-        // KPATH
+        // KPATH -> W
         clearArr(dids);
         clearArr(oids);
 
+        // this is a path we might want to say BLOCK it which would mean adding a BLOCK
+        // and an OPEN which we would set to false
         dids[0] = createDirObj(DirectionType.West, KPlain,
                                DirObjectType.Path, MaterialType.Stone,
                                "path", aids);
@@ -170,16 +191,6 @@ contract GameSetupSystem is System {
         createPlace(KMountainPath, dids, oids, tid_mpath);
     }
 
-    function createAction(bool isObj, uint32 oId, ActionType t, bool enable) private returns (uint32) {
-        //uint32 id = guid();
-        //ActionStore.set(id, t, enable);
-        //if (isObj == true) {
-            //ObjectStore.pushObjectActionIds(oId, id);
-        //} else {
-        //}
-
-    }
-
     function createDirObj(DirectionType dirType, uint32 dstId, DirObjectType dOType,
                                                     MaterialType mType,string memory desc, uint32[] memory actionObjects)
                                                                     private returns (uint32) {
@@ -190,22 +201,21 @@ contract GameSetupSystem is System {
         return dirObjId++;
     }
 
-    function createObject(ObjectType objType, MaterialType mType, string memory desc, string memory name) private returns (uint32){
+    function createObject(ObjectType objType, MaterialType mType, string memory desc, string memory name, uint32[] memory actions) private returns (uint32) {
         bytes32 txtId = keccak256(abi.encodePacked(desc));
         TxtDefStore.set(txtId, objId, TxtDefType.Object, desc);
-        uint32[] memory actions = new uint32[](0);
         ObjectStoreData memory objData = ObjectStoreData(objType, mType, txtId, actions, name);
         ObjectStore.set(objId, objData);
         return objId++;
     }
 
-    //function createAction(ActionType actionType, string memory desc, bool pBit) private returns (uint32){
-        ////bytes32 txtId = keccak256(abi.encodePacked(desc));
-        //// bodged in and broken FIXME we need a REAL objId
-        ////TxtDefStore.set(txtId, 0, actionId, actionType, desc);
-        ////ActionStoreData memory actionData = ActionStoreData(actionType,txtId,pBit);
-        ////ActionStore.set(actionId, actionData);
-        //return actionId++;
-    //}
+    function createAction(ActionType actionType, string memory desc, bool enabled, bool dBit) private returns (uint32) {
+        bytes32 txtId = keccak256(abi.encodePacked(desc));
+        uint32 aId = guid();
+        TxtDefStore.set(txtId, aId, TxtDefType.Action, desc);
+        ActionStoreData memory actionData = ActionStoreData(actionType, txtId, enabled, dBit);
+        ActionStore.set(aId, actionData);
+        return aId;
+    }
 
 }

--- a/packages/contracts/src/systems/GameSetupSystem.sol
+++ b/packages/contracts/src/systems/GameSetupSystem.sol
@@ -5,40 +5,34 @@ pragma solidity >=0.8.21;
 import { console } from "forge-std/console.sol";
 import { System } from "@latticexyz/world/src/System.sol";
 import { ErrCodes } from '../constants/defines.sol';
+import { Constants } from '../constants/Constants.sol';
 import { Description, ObjectStore, ObjectStoreData , DirObjectStore, DirObjectStoreData, Player, Output, CurrentPlayerId, RoomStore, RoomStoreData, ActionStore, ActionStoreData,TxtDefStore } from "../codegen/index.sol";
 import { ActionType, RoomType, ObjectType, CommandError, DirectionType, DirObjectType, TxtDefType, MaterialType } from "../codegen/common.sol";
 
-contract GameSetupSystem is System {
-
+contract GameSetupSystem is System, Constants {
+    
     uint32 dirObjId = 1;
     uint32 objId = 1;
     uint32 actionId = 1;
+
+    uint32 KForest = 3;
+    uint32 KPlain = 2;
+    uint32 KBarn = 1;
+    uint32 KMountainPath = 0;
     
-    // just for now
-    uint8 MAXOBJ = 16;
-
-    uint32[256] private map;
-
     function init() public returns (uint32) {
-
-        console.log("--->setup: init()");
         setupWorld();
-
-        // we are right now initing the data in the
-        Output.set('init called...');
         return 0;
-    }
-
-    function getArrayValue(uint8 index) public view returns (uint32, uint8 er) {
-        if (index > 255) {
-            return (0, ErrCodes.ER_AR_BNDS);
-        }
-        return (map[index], 0);
     }
 
     function setupWorld() private {
         setupRooms();
         setupPlayer();
+    }
+
+    function textGuid(string memory str) private returns (uint32) {
+        bytes4 trunc = bytes4(keccak256(abi.encodePacked(str)));
+        return uint32(trunc);
     }
 
     function guid() private view returns (uint32) {
@@ -50,24 +44,22 @@ contract GameSetupSystem is System {
                 msg.sender
             )
         );
-        return uint32(uint256(hash));
+        uint32 g = uint32(uint256(hash));
+        return g++;
     }
 
     function setupPlayer() private {
-        // tim, whats the method to create a random int32????
-        // Daren, there is no pseudo random number gen but there
-        // is some semi entropic stuff we can hash see guid()
         CurrentPlayerId.set(guid());
     }
 
-    function clearArr(uint32[] memory arr) private view {
+    function clearArr(uint32[MAX_OBJ] memory arr) private view {
         console.log("---> clear");
-        for (uint8 i = 0; i < MAXOBJ; i++) {
+        for (uint8 i = 0; i < MAX_OBJ; i++) {
             arr[i] = 0;
         }
     }
 
-    function createPlace(uint32 id, uint32[] memory dirObjects, uint32[] memory objects, bytes32 txtId) public {
+    function createPlace(uint32 id, uint32[32] memory dirObjects, uint32[32] memory objects, bytes32 txtId) public {
         for (uint8 i = 0; i < dirObjects.length; i++) {
                 RoomStore.pushDirObjIds(id, dirObjects[i]);
         }
@@ -76,48 +68,45 @@ contract GameSetupSystem is System {
         }
         RoomStore.setTxtDefId(id,txtId);
     }
-
-    function setupRooms() private {
-        uint32 KForest = 3;
-        uint32 KPlain = 2;
-        uint32 KBarn = 1;
-        uint32 KMountainPath = 0;
-
-        // if we go for 256 then the contract fails to deploy
-        // but we donr need that many anyway but essentially after
-        // > 32 we are back in uncharted waters
-        uint32[] memory dids = new uint32[](MAXOBJ);
-        uint32[] memory oids = new uint32[](MAXOBJ);
-        uint32[] memory aids = new uint32[](MAXOBJ);
-
+    
+    function _setupPlain() private {
         // KPLAIN -> N, E
-        aids[0] = createAction(ActionType.Open, "the door opens with a farty noise\n"
+        uint32 open_2_barn = createAction(ActionType.Open, "the door opens with a farty noise\n"
                                 "oddly you can actually smell fart",
                                 true, true);  
+        
+        uint32[MAX_OBJ] memory plain_barn;
+        uint32[MAX_OBJ] memory dObjs;
+        uint32[MAX_OBJ] memory objs;
+        
+        plain_barn[0] = open_2_barn;
 
-        dids[0] = createDirObj(DirectionType.North, KBarn, 
+        dObjs[0] = createDirObj(DirectionType.North, KBarn, 
                               DirObjectType.Path, MaterialType.Dirt, 
-                              "path", aids);
+                              "path", plain_barn);
 
-        aids[1] = createAction(ActionType.Open, "the door opens and a small hinge demon curses you\n"
+        uint32 open_2_path = createAction(ActionType.Open, "the door opens and a small hinge demon curses you\n"
                                 "your nose is really itchy",
                                 true, true);  
 
-        dids[1] = createDirObj(DirectionType.East, KMountainPath, 
+        uint32[MAX_OBJ] memory plain_path;
+        plain_barn[0] = open_2_path;
+        dObjs[1] = createDirObj(DirectionType.East, KMountainPath, 
                               DirObjectType.Path, MaterialType.Mud,
-                              "path", aids);
-       clearArr(aids); 
+                              "path", plain_path);
 
-        // football is gay 
-        aids[0] = createAction(ActionType.Kick, "the ball (such as it is)"
+        uint32 kick = createAction(ActionType.Kick, "the ball (such as it is)"
                                 "bounces feebly\n then rolls into some fresh dog eggs\n"
                                 "none the less you briefly feel a little better",
                                 true, false);  
+        
+        uint32[MAX_OBJ] memory ball_actions;
+        ball_actions[0] = kick;
 
-        oids[0] = createObject(ObjectType.Football, MaterialType.Flesh,
+        objs[0] = createObject(ObjectType.Football, MaterialType.Flesh,
                                 "A slightly deflated knock off uefa football,\n"
                                 "not quite spherical, it's "
-                                "kickable though", "football", aids);
+                                "kickable though", "football", ball_actions);
 
         RoomStore.setDescription(KPlain,  'a windswept plain');
         RoomStore.setRoomType(KPlain,  RoomType.Plain);
@@ -128,31 +117,37 @@ contract GameSetupSystem is System {
                                                                 "cover the plains as far as your eye can see\n"
                                                                 "the air tastes of burnt grease and bensons.");
 
-        createPlace(KPlain, dids, oids, tid_plain);
+        createPlace(KPlain, dObjs, objs, tid_plain);
+    }
 
-
+    function _setupBarn() private {
         // KBARN -> S
         // TODO add a smash action to the window
-        clearArr(dids);
-        clearArr(oids);
-        clearArr(aids);
-        
-        aids[0] = createAction(ActionType.Open, "the door opens\n", true, true);
+        uint32 open_2_south = createAction(ActionType.Open, "the door opens\n", true, true);
+        uint32[MAX_OBJ] memory barn_plain;
+        barn_plain[0] = open_2_south;
 
-        dids[0] = createDirObj(DirectionType.South, KPlain,
+        uint32[MAX_OBJ] memory dObjs;
+        uint32[MAX_OBJ] memory objs;
+        dObjs[0] = createDirObj(DirectionType.South, KPlain,
                                 DirObjectType.Door, MaterialType.Wood,
-                                "door", aids); 
-        clearArr(aids);
-        aids[0] = createAction(ActionType.Open, "the window, glass and frame smashed"
+                                "door", barn_plain); 
+
+        uint32 open_2_forest = createAction(ActionType.Open, "the window, glass and frame smashed"
                                 "falls open\n", true, false);
-        aids[1] = createAction(ActionType.Break, "I love the sound of breaking glass\n"
+        
+        uint32 smash_window = createAction(ActionType.Break, "I love the sound of breaking glass\n"
                                 "especially when I'm lonely, the panes and the frame shatter\n"
                                 "satisfyingly spreading broken joy on the floor"
                                 , true, false);
 
-        dids[1] = createDirObj(DirectionType.East, KForest,
+        uint32[MAX_OBJ] memory window_actions;
+        window_actions[0] = open_2_forest;
+        window_actions[1] = smash_window;
+
+        dObjs[1] = createDirObj(DirectionType.East, KForest,
                                 DirObjectType.Window, MaterialType.Wood,
-                                "window", aids); 
+                                "window", window_actions); 
 
         bytes32 tid_barn = keccak256(abi.encodePacked("a barn"));
         TxtDefStore.set(tid_barn, KBarn, TxtDefType.Place, 
@@ -161,20 +156,26 @@ contract GameSetupSystem is System {
                                                     "plenty of corners and dark shadows");
 
 
-        RoomStore.setDescription(KBarn, 'a barn');// this should be auto gen
+        RoomStore.setDescription(KBarn, 'a barn'); // this should be auto gen
         RoomStore.setRoomType(KBarn, RoomType.Room);
 
-        createPlace(KBarn, dids, oids, tid_barn);
+        createPlace(KBarn, dObjs, objs, tid_barn);
+    }
 
+    function _createMountainPath() private {
         // KPATH -> W
-        clearArr(dids);
-        clearArr(oids);
+        uint32 open_2_west = createAction(ActionType.Open, "the path is passable", true, true); 
+        uint32[MAX_OBJ] memory path_actions;
+        path_actions[0] = open_2_west;
 
+        uint32[MAX_OBJ] memory dirObjs;
+        uint32[MAX_OBJ] memory objs;
         // this is a path we might want to say BLOCK it which would mean adding a BLOCK
-        // and an OPEN which we would set to false
-        dids[0] = createDirObj(DirectionType.West, KPlain,
+        // and an OPEN which we would set to false but as can be seen above right
+        // now its just open and there is no state change to describe it
+        dirObjs[0] = createDirObj(DirectionType.West, KPlain,
                                DirObjectType.Path, MaterialType.Stone,
-                               "path", aids);
+                               "path", path_actions);
 
 
 
@@ -188,11 +189,18 @@ contract GameSetupSystem is System {
 
         RoomStore.setDescription(KMountainPath,  "a high mountain pass");
         RoomStore.setRoomType(KMountainPath,  RoomType.Plain);
-        createPlace(KMountainPath, dids, oids, tid_mpath);
+        createPlace(KMountainPath, dirObjs, objs, tid_mpath);
+
+    }
+
+    function setupRooms() private {
+        _setupPlain();
+        _setupBarn();
+        _createMountainPath();
     }
 
     function createDirObj(DirectionType dirType, uint32 dstId, DirObjectType dOType,
-                                                    MaterialType mType,string memory desc, uint32[] memory actionObjects)
+                                                    MaterialType mType,string memory desc, uint32[MAX_OBJ] memory actionObjects)
                                                                     private returns (uint32) {
         bytes32 txtId = keccak256(abi.encodePacked(desc));
         TxtDefStore.set(txtId, dirObjId, TxtDefType.DirObject, desc);
@@ -201,7 +209,7 @@ contract GameSetupSystem is System {
         return dirObjId++;
     }
 
-    function createObject(ObjectType objType, MaterialType mType, string memory desc, string memory name, uint32[] memory actions) private returns (uint32) {
+    function createObject(ObjectType objType, MaterialType mType, string memory desc, string memory name, uint32[MAX_OBJ] memory actions) private returns (uint32) {
         bytes32 txtId = keccak256(abi.encodePacked(desc));
         TxtDefStore.set(txtId, objId, TxtDefType.Object, desc);
         ObjectStoreData memory objData = ObjectStoreData(objType, mType, txtId, actions, name);
@@ -211,7 +219,7 @@ contract GameSetupSystem is System {
 
     function createAction(ActionType actionType, string memory desc, bool enabled, bool dBit) private returns (uint32) {
         bytes32 txtId = keccak256(abi.encodePacked(desc));
-        uint32 aId = guid();
+        uint32 aId = textGuid(desc);
         TxtDefStore.set(txtId, aId, TxtDefType.Action, desc);
         ActionStoreData memory actionData = ActionStoreData(actionType, txtId, enabled, dBit);
         ActionStore.set(aId, actionData);

--- a/packages/contracts/src/systems/InventorySystem.sol
+++ b/packages/contracts/src/systems/InventorySystem.sol
@@ -6,16 +6,17 @@ import {System} from "@latticexyz/world/src/System.sol";
 import {IWorld} from '../codegen/world/IWorld.sol';
 
 import {ObjectType} from '../codegen/common.sol';
+import {Constants} from '../constants/Constants.sol';
 import {Player, CurrentPlayerId, RoomStore, ObjectStore, Output} from '../codegen/index.sol';
 
-contract InventorySystem is System {
+contract InventorySystem is System, Constants {
     function take(address world, string[] memory tokens, uint32 rId) public returns (uint8 err) {
         console.log("----->TAKE :", tokens[1]);
         uint8 tok_err;
         string memory tok = tokens[1];
         ObjectType objType = IWorld(world).meat_TokeniserSystem_getObjectType(tok);
         if (objType != ObjectType.None) {
-            uint32[] memory objIds = RoomStore.getObjectIds(rId);
+            uint32[MAX_OBJ] memory objIds = RoomStore.getObjectIds(rId);
             for (uint8 i = 0; i < objIds.length; i++) {
                 ObjectType testType = ObjectStore.getObjectType(objIds[i]);
                 if (testType == objType) {
@@ -39,7 +40,7 @@ contract InventorySystem is System {
         ObjectType objType = IWorld(world).meat_TokeniserSystem_getObjectType(tok);
         if (objType != ObjectType.None) {
             console.log("1");
-            uint32[] memory objIds = Player.getObjectIds(CurrentPlayerId.get());
+            uint32[MAX_OBJ] memory objIds = Player.getObjectIds(CurrentPlayerId.get());
             for (uint8 i = 0; i < objIds.length; i++) {
                 console.log("2");
                 ObjectType testType = ObjectStore.getObjectType(objIds[i]);

--- a/packages/contracts/src/systems/MeatPuppetSystem.sol
+++ b/packages/contracts/src/systems/MeatPuppetSystem.sol
@@ -2,24 +2,30 @@
 pragma solidity >=0.8.21;
 
 // get some debug OUT going
-import {console} from "forge-std/console.sol";
+import { console } from "forge-std/console.sol";
 
 import { System } from "@latticexyz/world/src/System.sol";
+
 import { ObjectStoreData, ObjectStore,Player, Output, CurrentPlayerId, RoomStore, RoomStoreData, ActionStore, DirObjectStore,
     DirObjectStoreData, TxtDefStore } from "../codegen/index.sol";
+
 import { ActionType, RoomType, ObjectType, CommandError, DirectionType } from "../codegen/common.sol";
+
 import { GameConstants, ErrCodes, ResCodes } from "../constants/defines.sol";
 
 import { IInventorySystem } from '../codegen/world/IInventorySystem.sol';
 
-import {IWorld} from "../codegen/world/IWorld.sol";
-import {LookAt} from '../libs/LookLib.sol';
-import {Kick} from '../libs/KickLib.sol';
-import {console} from "forge-std/console.sol";
+import { IWorld } from "../codegen/world/IWorld.sol";
 
-contract MeatPuppetSystem is System {
+import { LookAt } from '../libs/LookLib.sol';
 
-    event debugLog(string msg, uint8 val);
+import { Kick } from '../libs/KickLib.sol';
+
+import { Constants } from '../constants/Constants.sol';
+
+
+contract MeatPuppetSystem is System, Constants {
+
     using LookAt for *;
 
     address world;
@@ -72,7 +78,7 @@ contract MeatPuppetSystem is System {
         return _describeObjects(Player.getObjectIds(CurrentPlayerId.get()), "\nYour Aldi carrier bag contains ");
     }
 
-    function _describeObjects(uint32[] memory objectIds, string memory preText) private returns (string memory) {
+    function _describeObjects(uint32[MAX_OBJ] memory objectIds, string memory preText) private returns (string memory) {
         console.log("--------->DescribeObjects:");
 
         bool foundValidObject = false;


### PR DESCRIPTION
Fixes dynamic array sizes to 32.
Adds a constant for this (where we can).
Adds a guid gen from a string as the other guid generator will return the same value each call in the same block.
Adds checking for open on dObjects.
Splits game setup room gene into separate function calls.

